### PR TITLE
async-timeout version conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ aiohttp==3.8.1
 async-timeout==4.0.1
 anyio==3.2.1
 asgiref==3.3.4
-async-timeout==3.0.1
 asyncpg==0.23.0
 attrs==21.2.0
 beautifulsoup4==4.9.3


### PR DESCRIPTION
Just purchased your book and ran into a minor issue with the requirements.

> ERROR: Cannot install async-timeout==3.0.1 and async-timeout==4.0.1 because these package versions have conflicting dependencies.
> 
> The conflict is caused by:
>     The user requested async-timeout==4.0.1
>     The user requested async-timeout==3.0.1

Looking forward to learning asyncio. thx!