### PR TITLE
Fix type hints for "socket" objects.

### DIFF
--- a/chapter_03/listing_3_8.py
+++ b/chapter_03/listing_3_8.py
@@ -3,13 +3,13 @@ import socket
 from asyncio import AbstractEventLoop
 
 
-async def echo(connection: socket,
+async def echo(connection: socket.socket,
                loop: AbstractEventLoop) -> None:
     while data := await loop.sock_recv(connection, 1024):
         await loop.sock_sendall(connection, data)
 
 
-async def listen_for_connection(server_socket: socket,
+async def listen_for_connection(server_socket: socket.socket,
                                 loop: AbstractEventLoop):
     while True:
         connection, address = await loop.sock_accept(server_socket)

--- a/chapter_07/listing_7_1.py
+++ b/chapter_07/listing_7_1.py
@@ -2,7 +2,7 @@ from threading import Thread
 import socket
 
 
-def echo(client: socket):
+def echo(client: socket.socket):
     while True:
         data = client.recv(2048)
         print(f'Received {data}, sending!')

--- a/chapter_14/listing_14_10.py
+++ b/chapter_14/listing_14_10.py
@@ -5,17 +5,17 @@ from listing_14_8 import CustomFuture
 from selectors import BaseSelector
 
 
-def accept_connection(future: CustomFuture, connection: socket): #A
+def accept_connection(future: CustomFuture, connection: socket.socket): #A
     print(f'We got a connection from {connection}!')
     future.set_result(connection)
 
 
-async def sock_accept(sel: BaseSelector, sock) -> socket: #B
+async def sock_accept(sel: BaseSelector, sock) -> socket.socket: #B
     print('Registering socket to listen for connections')
     future = CustomFuture()
     sel.register(sock, selectors.EVENT_READ, functools.partial(accept_connection, future))
     print('Pausing to listen for connections...')
-    connection: socket = await future
+    connection: socket.socket = await future
     return connection
 
 


### PR DESCRIPTION
Hi,
The `socket` module itself was used as the type hint. It should be `socket.socket` class. Mypy currently says:

```none
file2.py:6: error: Module "socket" is not valid as a type  [valid-type]
file2.py:12: error: Module "socket" is not valid as a type  [valid-type]
```
Thanks.